### PR TITLE
Sync trivy-action with Remix template and update dependencies

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -28,12 +28,14 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          # specify multiple registries: try default GitHub registry, if too many requests, use the aws mirror
+          # Specify multiple registries: try default GitHub registry, if too many requests, use the aws mirror.
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           scanners: "vuln"
           scan-type: "fs"
           format: "sarif"
+          # By default SARIF format enforces output of all vulnerabilities regardless of configured severities.
+          # To override this set limit-severities-for-sarif to true.
           limit-severities-for-sarif: true
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -34,6 +34,7 @@ jobs:
           scanners: "vuln"
           scan-type: "fs"
           format: "sarif"
+          limit-severities-for-sarif: true
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
           exit-code: "1" # Fail the build!

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@5681af892cd0f4997658e2bacc62bd0a894cf564 # v0.27.0
         env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           # specify multiple registries: try default GitHub registry, if too many requests, use the aws mirror
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2375,6 +2375,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@remix-run/css-bundle/-/css-bundle-2.13.1.tgz",
       "integrity": "sha512-ukams+HcEaovitySAmH2Q8Gg8c6A3fKr5RJEpAn0NYk1Cc2t0fH05GVAGToOgtWeFeOUjREXAqk3+C76o0cHkg==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2384,6 +2385,7 @@
       "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.13.1.tgz",
       "integrity": "sha512-7+06Dail6zMyRlRvgrZ4cmQjs2gUb+M24iP4jbmql+0B7VAAPwzCRU0x+BF5z8GSef13kDrH3iXv/BQ2O2yOgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.8",
         "@babel/generator": "^7.21.5",
@@ -2488,6 +2490,7 @@
       "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-2.13.1.tgz",
       "integrity": "sha512-UNWRHYa++pWrO6qxNI9z7KrmD0/wncWjS36TujoPmlnVDQ2pKIhNZwBi6otJQIuI8TdUPBZstJNgRJ0TWYok6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.8",
         "@babel/eslint-parser": "^7.21.8",
@@ -2524,6 +2527,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.13.1.tgz",
       "integrity": "sha512-yl3/BSJ8eyvwUyWCLDq3NlS81mZFll9hnADNuSCCBrQgkMhEx7stk5JUmWdvmcmGqHw04Ahkq07ZqJeD4F1FMA==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/node": "2.13.1"
       },
@@ -2544,6 +2548,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.13.1.tgz",
       "integrity": "sha512-2ly7bENj2n2FNBdEN60ZEbNCs5dAOex/QJoo6EZ8RNFfUQxVKAZkMwfQ4ETV2SLWDgkRLj3Jo5n/dx7O2ZGhGw==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/server-runtime": "2.13.1",
         "@remix-run/web-fetch": "^4.4.2",
@@ -2569,6 +2574,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.13.1.tgz",
       "integrity": "sha512-kZevCoKMz0ZDOOzTnG95yfM7M9ju38FkWNY1wtxCy+NnUJYrmTerGQtiBsJgMzYD6i29+w4EwoQsdqys7DmMSg==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.20.0",
         "@remix-run/server-runtime": "2.13.1",
@@ -2594,6 +2600,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
       "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2602,6 +2609,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.13.1.tgz",
       "integrity": "sha512-lKCU1ZnHaGknRAYII5PQOGch9xzK3Q68mcyN8clN6WoKQTn5fvWVE1nEDd1L7vyt5LPVI2b7HNQtVMow1g1vHg==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/express": "2.13.1",
         "@remix-run/node": "2.13.1",
@@ -2623,6 +2631,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.13.1.tgz",
       "integrity": "sha512-2DfBPRcHKVzE4bCNsNkKB50BhCCKF73x+jiS836OyxSIAL+x0tguV2AEjmGXefEXc5AGGzoxkus0AUUEYa29Vg==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.20.0",
         "@types/cookie": "^0.6.0",
@@ -3342,9 +3351,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4630,9 +4639,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001667",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+      "version": "1.0.30001668",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz",
+      "integrity": "sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==",
       "dev": true,
       "funding": [
         {
@@ -5067,9 +5076,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5697,9 +5706,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.35",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.35.tgz",
-      "integrity": "sha512-hOSRInrIDm0Brzp4IHW2F/VM+638qOL2CzE0DgpnGzKW27C95IqqeqgKz/hxHGnvPxvQGpHUGD5qRVC9EZY2+A==",
+      "version": "1.5.36",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.36.tgz",
+      "integrity": "sha512-HYTX8tKge/VNp6FGO+f/uVDmUkq+cEfcxYhKf15Akc4M5yxt5YmorwlAitKWjWhWQnKcDRBAQKXkhqqXMqcrjw==",
       "dev": true,
       "license": "ISC"
     },
@@ -12114,13 +12123,13 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.0.tgz",
+      "integrity": "sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.5.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -13007,6 +13016,7 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
       "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.20.0"
       },
@@ -13021,6 +13031,7 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
       "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.20.0",
         "react-router": "6.27.0"
@@ -15247,9 +15258,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.0.tgz",
-      "integrity": "sha512-AITZfPuxubm31Sx0vr8bteSalEbs9wQb/BOBi9FPlD9Qpd6HxZ4Q0+hI742jBhkPb4RT2v5MQzaW5VhRVyj+9A==",
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
+      "integrity": "sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -15664,9 +15675,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
-      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.9.tgz",
+      "integrity": "sha512-20OVpJHh0PAM0oSOELa5GaZNWeDjcAvQjGXy2Uyr+Tp+/D2/Hdz6NLgpJLsarPTA2QJ6v8mX2P1ZfbsSKvdMkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16563,9 +16574,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
+      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -53,10 +53,5 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  },
-  "overrides": {
-    "@remix-run/server-runtime": {
-      "cookie": "^0.7.2"
-    }
   }
 }


### PR DESCRIPTION
This will 
- clean up the `trivy-action` configuration
- remove the `overrides` configuration within the `package.json` (was used to get rid of low severity vulnerabilities that failed the trivy scan)
- and update the `trivy-action` config with `limit-severities-for-sarif: true` [input](https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#inputs), so that configured severity with `CRITICAL,HIGH` will be recognized correctly. See https://github.com/aquasecurity/trivy-action/issues/309 for reference (thanks @HendrikSchmidt).